### PR TITLE
ci: get to green the right way

### DIFF
--- a/.github/workflows/proto-breaking-check.yml
+++ b/.github/workflows/proto-breaking-check.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   proto-breaking-check:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'merge-') }}
     runs-on: depot-ubuntu-22.04-4
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ ADD LICENSE LICENSE
 COPY contrib/devtools/Makefile contrib/devtools/Makefile
 COPY Makefile .
 
-COPY go.mod .
-COPY go.sum .
+COPY go.* .
+RUN test ! -f go.work || go work edit -dropuse './e2e'
 
 RUN go mod download
 

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -466,7 +466,7 @@ func NewSimApp(
 			txConfig,
 		),
 		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),
-		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
+		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper, app.GetSubspace(banktypes.ModuleName)),
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, app.GetSubspace(crisistypes.ModuleName)),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),


### PR DESCRIPTION
## Description

#14 landed and was released with known CI issues.  We decided to proceed, judging that the changes needed to achieve a fully green CI were not substantial but would require some effort.

This PR captures these tiny touches, where our AI buddies needed to let the hoomans do the work.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Linked to GitHub issue with discussion and accepted design, OR link to spec that describes this work.
- [ ] Include changelog entry when appropriate (e.g. chores should be omitted from changelog).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/main/testing/README.md#ibc-testing-package) if relevant.
- [ ] Updated documentation (`docs/`) if anything is changed.
- [ ] Added `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code) if relevant.
- [ ] Self-reviewed `Files changed` in the GitHub PR explorer.
- [ ] Provide a [conventional commit message](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) to follow the repository standards.
    <!-- Please refer to the [guidelines](https://github.com/cosmos/ibc-go/blob/main/docs/dev/pull-requests.md#commit-messages) for commit messages in ibc-go.
    This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
    Example commit messages:
    fix: skip emission of unpopulated memo field in ics20
    deps: updating sdk to v0.46.4
    chore: removed unused variables
    e2e: adding e2e upgrade test for ibc-go/v6
    docs: ics27 v6 documentation updates
    feat: add semantic version utilities for e2e tests
    feat(api)!: this is an api breaking feature
    fix(statemachine)!: this is a statemachine breaking fix
    -->
